### PR TITLE
iOS26で共有メニューを閉じた後に結果が返されない不具合の修正

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -39,47 +39,6 @@ TopViewControllerForViewController(UIViewController *viewController) {
   return viewController;
 }
 
-// We need the companion to avoid ARC deadlock
-@interface UIActivityViewSuccessCompanion : NSObject
-
-@property FlutterResult result;
-@property NSString *activityType;
-@property BOOL completed;
-
-- (id)initWithResult:(FlutterResult)result;
-
-@end
-
-@implementation UIActivityViewSuccessCompanion
-
-- (id)initWithResult:(FlutterResult)result {
-  if (self = [super init]) {
-    self.result = result;
-    self.completed = false;
-  }
-  return self;
-}
-
-// We use dealloc as the share-sheet might disappear (e.g. iCloud photo album
-// creation) and could then reappear if the user cancels
-- (void)dealloc {
-  if (self.completed) {
-    self.result(self.activityType);
-  } else {
-    self.result(@"");
-  }
-}
-
-@end
-
-@interface UIActivityViewSuccessController : UIActivityViewController
-
-@property UIActivityViewSuccessCompanion *companion;
-
-@end
-
-@implementation UIActivityViewSuccessController
-@end
 
 @interface SharePlusData : NSObject <UIActivityItemSource>
 
@@ -361,9 +320,9 @@ TopViewControllerForViewController(UIViewController *viewController) {
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
-  UIActivityViewSuccessController *activityViewController =
-      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
-                                               applicationActivities:nil];
+  UIActivityViewController *activityViewController =
+      [[UIActivityViewController alloc] initWithActivityItems:shareItems
+                                        applicationActivities:nil];
 
   // Force subject when sharing a raw url or files
   if (![subject isKindOfClass:[NSNull class]]) {
@@ -397,14 +356,14 @@ TopViewControllerForViewController(UIViewController *viewController) {
     activityViewController.popoverPresentationController.sourceRect = origin;
   }
 
-  UIActivityViewSuccessCompanion *companion =
-      [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
-  activityViewController.companion = companion;
   activityViewController.completionWithItemsHandler =
       ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
         NSError *activityError) {
-        companion.activityType = activityType;
-        companion.completed = completed;
+        if (completed) {
+          result(activityType);
+        } else {
+          result(@"");
+        }
       };
 
   [controller presentViewController:activityViewController


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

